### PR TITLE
Responds to PR feedback from UC

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -10,7 +10,9 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Workable\Workable:
     constructor:
       0: %$WorkableRestfulService
-      1: %$Psr\SimpleCache\CacheInterface.workable
+      1: '%$Psr\SimpleCache\CacheInterface.workable'
   WorkableRestfulService:
     class: GuzzleHttp\Client
     factory: SilverStripe\Workable\WorkableRestfulServiceFactory
+SilverStripe\Workable\Workable:
+  apikey: '`WORKABLE_API_KEY`'

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -9,10 +9,11 @@ SilverStripe\Core\Injector\Injector:
       defaultLifetime: 3600
   SilverStripe\Workable\Workable:
     constructor:
-      0: %$WorkableRestfulService
+      0: '%$GuzzleHttp\ClientInterface.workable'
       1: '%$Psr\SimpleCache\CacheInterface.workable'
-  WorkableRestfulService:
+  SilverStripe\Workable\WorkableRestfulServiceFactory:
+    constructor:
+      apikey: '`WORKABLE_API_KEY`'
+  GuzzleHttp\ClientInterface.workable:
     class: GuzzleHttp\Client
     factory: SilverStripe\Workable\WorkableRestfulServiceFactory
-SilverStripe\Workable\Workable:
-  apikey: '`WORKABLE_API_KEY`'

--- a/code/Workable.php
+++ b/code/Workable.php
@@ -38,7 +38,7 @@ class Workable implements Flushable
      * Subdomain for Workable API call (e.g. $subdomain.workable.com)
      * @config
      */
-    private $subdomain;
+    private static $subdomain;
 
     /**
      * Constructor, inject the restful service dependency

--- a/code/WorkableRestfulServiceFactory.php
+++ b/code/WorkableRestfulServiceFactory.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Workable;
 
+use GuzzleHttp\ClientInterface;
 use RuntimeException;
 use SilverStripe\Workable\Workable;
 use SilverStripe\Core\Injector\Factory;
@@ -16,30 +17,42 @@ use SilverStripe\Core\Injector\Factory;
  */
 class WorkableRestfulServiceFactory implements Factory
 {
+    /**
+     * Set via ENV variable WORKABLE_API_KEY (see config.yml)
+     * @var string
+     */
+    private $apiKey;
 
-
+    public function __construct(?string $apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
     /**
      * Create the RestfulService (or whatever dependency you've injected)
-     * @return RestfulService
+     *
+     * @throws RuntimeException
+     *
+     * @return ClientInterface
      */
     public function create($service, array $params = [])
     {
-        $config = Workable::config();
 
-        if (!$config->apiKey) {
+        if (!$this->apiKey) {
             throw new RuntimeException('WORKABLE_API_KEY Environment variable not set');
         }
 
-        if (!$config->subdomain) {
+        $subdomain = Workable::config()->subdomain;
+
+        if (!$subdomain) {
             throw new RuntimeException(
                 'You must set a Workable subdomain in the config (SilverStripe\Workable\Workable.subdomain)'
             );
         }
 
         return new $service([
-            'base_uri' => sprintf('https://%s.workable.com/spi/v3/', $config->subdomain),
+            'base_uri' => sprintf('https://%s.workable.com/spi/v3/', $subdomain),
             'headers' => [
-                'Authorization' => sprintf('Bearer %s', $config->apiKey),
+                'Authorization' => sprintf('Bearer %s', $this->apiKey),
             ],
         ]);
     }

--- a/code/WorkableRestfulServiceFactory.php
+++ b/code/WorkableRestfulServiceFactory.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\Workable;
 
 use RuntimeException;
-use SilverStripe\Core\Environment;
 use SilverStripe\Workable\Workable;
 use SilverStripe\Core\Injector\Factory;
 
@@ -17,29 +16,30 @@ use SilverStripe\Core\Injector\Factory;
  */
 class WorkableRestfulServiceFactory implements Factory
 {
+
+
     /**
      * Create the RestfulService (or whatever dependency you've injected)
      * @return RestfulService
      */
     public function create($service, array $params = [])
     {
-        $apiKey = Environment::getEnv('WORKABLE_API_KEY');
-        $subdomain = Workable::config()->subdomain;
+        $config = Workable::config();
 
-        if (!$apiKey) {
+        if (!$config->apiKey) {
             throw new RuntimeException('WORKABLE_API_KEY Environment variable not set');
         }
 
-        if (!$subdomain) {
+        if (!$config->subdomain) {
             throw new RuntimeException(
                 'You must set a Workable subdomain in the config (SilverStripe\Workable\Workable.subdomain)'
             );
         }
 
         return new $service([
-            'base_uri' => sprintf('https://%s.workable.com/spi/v3/', $subdomain),
+            'base_uri' => sprintf('https://%s.workable.com/spi/v3/', $config->subdomain),
             'headers' => [
-                'Authorization' => sprintf('Bearer %s', $apiKey),
+                'Authorization' => sprintf('Bearer %s', $config->apiKey),
             ],
         ]);
     }

--- a/code/WorkableResult.php
+++ b/code/WorkableResult.php
@@ -26,10 +26,7 @@ class WorkableResult extends ViewableData
     {
         $snaked = ltrim(strtolower(preg_replace('/[A-Z]/', '_$0', $prop)), '_');
 
-        if (!isset($this->apiData[$snaked])) {
-            return null;
-        }
-        $data = $this->apiData[$snaked];
+        $data = $this->apiData[$snaked] ?? null;
 
         if (is_array($this->apiData[$snaked])) {
             return new WorkableResult($data);

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require": {
     "silverstripe/framework": "^4",
     "guzzlehttp/guzzle": "^6",
-    "php": ">=5.6"
+    "php": ">=7.1"
   },
   "authors":[
     {


### PR DESCRIPTION
- Updates for PHP7 (type hinting, `null` coalescing)
- Now throws when the API request fails to differentiate from an empty list being returned
- Now injects env variable into Restful Service for easier testing

Maybe should just PR from my own fork if it needs more work from here.